### PR TITLE
streamlined tests

### DIFF
--- a/spec/my_each_spec.rb
+++ b/spec/my_each_spec.rb
@@ -2,22 +2,18 @@ require_relative 'spec_helper'
 require 'pry'
 
 describe "my_each" do
+  file = File.read('./my_each.rb')
+  contents = file.split(%r{\s|\.}).uniq
+  
   it "does not call on each" do
-    words = ['hi', 'hello', 'bye', 'goodbye']
-
-    expect(words).to_not receive(:each)
-
+    expect(contents).to_not include("each")
   end
 
   it "does not call on puts" do
-    file = File.read('./my_each.rb')
-    contents = file.split(" ")
     expect(contents).to_not include("puts")
   end
 
   it "calls on while" do
-    file = File.read('./my_each.rb')
-    contents = file.split(" ")
     expect(contents).to include("while")
   end
 
@@ -55,17 +51,12 @@ describe "my_each" do
 
   it "returned array contains the same elements as the original collection" do
     tas = ['arel', 'jon', 'logan', 'spencer']
-    # array may be modified by the iteration function so
-    # we cannot use it for verifying the results
-    # therefore we create a new copy using the clone method
-    tas_original = tas.clone
 
     # run the method
-    # check if it returns correct values
     expect(my_each(tas) do |ta|
-      # Do nothing on yield
+    # Do nothing on yield
+    # check if it returns correct values
     end).to contain_exactly('arel', 'jon', 'logan', 'spencer')
-
   end
 
   it "does not modify the original collection" do
@@ -83,7 +74,6 @@ describe "my_each" do
     # is verifying if the array we passed to method
     # has not been modified
     expect(tas).to eq(tas_original)
-
     end
 
   it "block is run n times" do
@@ -96,20 +86,16 @@ describe "my_each" do
     end
 
     expect(times_called).to eq(expected)
-
   end
 
-  it "only single element is passed into block" do
+  it "only passes a single element into the block at a time" do
 
     tas = ['arel', 'jon', 'logan', 'spencer']
-    expected = tas.length
-    times_called = 0
 
     my_each(tas) do |ta|
-      # cannot be an array
+      # ta cannot be an array
       expect(ta.kind_of?(Array)).to eq(false)
       expect(ta.kind_of?(String)).to eq(true)
     end
-
   end
 end

--- a/spec/my_each_spec.rb
+++ b/spec/my_each_spec.rb
@@ -3,18 +3,17 @@ require 'pry'
 
 describe "my_each" do
   file = File.read('./my_each.rb')
-  contents = file.split(%r{\s|\.}).uniq
   
-  it "does not call on each" do
-    expect(contents).to_not include("each")
+  it "does not call on .each" do
+    expect(file).to_not include(".each")
   end
 
   it "does not call on puts" do
-    expect(contents).to_not include("puts")
+    expect(file).to_not include("puts")
   end
 
   it "calls on while" do
-    expect(contents).to include("while")
+    expect(file).to include("while")
   end
 
   it "iterates over each element" do


### PR DESCRIPTION
Made the "does not call on each" test functional; streamlined all of the `expect(contents)` tests; removed the `tas_original` variable from the "same elements as the original collection" test, where it wasn't being used for anything; reworded the description of the "single element" test and removed the `expected` and `times_called` variables, neither of which were being used for anything